### PR TITLE
fix stub copyFileRange in reflink.go

### DIFF
--- a/reflink.go
+++ b/reflink.go
@@ -13,5 +13,5 @@ func reflinkRangeInternal(dst, src *os.File, dstOffset, srcOffset, n int64) erro
 }
 
 func copyFileRange(dst, src *os.File, dstOffset, srcOffset, n int64) (int64, error) {
-	return ErrReflinkUnsupported
+	return 0, ErrReflinkUnsupported
 }


### PR DESCRIPTION
Doesn't build on macos without this.