### PR TITLE
Repeat copy_file_range until complete #3

### DIFF
--- a/reflink_linux.go
+++ b/reflink_linux.go
@@ -116,8 +116,14 @@ func copyFileRange(dst, src *os.File, dstOffset, srcOffset, n int64) (int64, err
 
 	err = sd.Control(func(dfd uintptr) {
 		err2 = ss.Control(func(sfd uintptr) {
-			// call syscall
-			resN, err3 = unix.CopyFileRange(int(sfd), &srcOffset, int(dfd), &dstOffset, int(n), 0)
+			for rn := n; rn > 0; {
+				// call syscall
+				resN, err3 = unix.CopyFileRange(int(sfd), &srcOffset, int(dfd), &dstOffset, int(rn), 0)
+				if err3 != nil || resN == 0 {
+					break
+				}
+				rn -= int64(resN)
+			}
 		})
 	})
 


### PR DESCRIPTION
This PR modifies copyFileRange to loop over the copy_file_range syscall until the expected number of bytes have been copied and resolves #3. Without this change, files larger than 2,147,479,552 bytes may be truncated.